### PR TITLE
Asset tag not required

### DIFF
--- a/src/application/models/AssetManager_model.php
+++ b/src/application/models/AssetManager_model.php
@@ -106,7 +106,7 @@ class AssetManager_model extends CI_Model {
         $asset_tag_rules = array(
             'field' => $this->fields['asset_tag'],
             'label' => 'asset tag',
-            'rules' => 'required|callback_is_asset_tag_unique|trim',
+            'rules' => 'callback_is_asset_tag_unique|trim',
             'errors' => array (
                 'is_asset_tag_unique' => 'The %s field must contain a unique value.'
             )
@@ -211,7 +211,7 @@ class AssetManager_model extends CI_Model {
         $asset_tag_rules = array(
             'field' => $this->fields['asset_tag'],
             'label' => 'asset tag',
-            'rules' => 'required|callback_is_asset_tag_unique_not_different_from_current|trim',
+            'rules' => 'callback_is_asset_tag_unique_not_different_from_current|trim',
             'errors' => array (
                 'is_asset_tag_unique_not_different_from_current' => 'The %s field must contain a unique value.'
             )

--- a/src/application/models/AssetManager_model.php
+++ b/src/application/models/AssetManager_model.php
@@ -349,6 +349,10 @@ class AssetManager_model extends CI_Model {
 
     public function is_asset_tag_unique($asset_tag) {
         log_message('debug', 'AssetManager_model: is_asset_tag_unique - in function');
+        
+        if (!isset($asset_tag) || $asset_tag == NULL) {
+            return TRUE;
+        }
 
         $this->db->select($this->fields['asset_tag']);
         $this->db->from($this->table);

--- a/src/application/views/private/modals/assets/add.php
+++ b/src/application/views/private/modals/assets/add.php
@@ -45,7 +45,7 @@
                     </div>
                     <div class="row">
                         <div class="col-md form-group">
-                            <label>Asset Tag<span class="required"> *</span></label>
+                            <label>Asset Tag</label>
                             <input type="text" id="add-asset-asset-tag" name="asset_tag" class="form-control" value="<?php set_value('asset_tag'); ?>">
                             <div id="add-asset-asset-tag-error" class="invalid-feedback"></div>
                         </div>


### PR DESCRIPTION
Resolves issue #25.

## Enhancement
* Removes required validation from the asset manager asset tag field