### PR TITLE
Align dropdown text

### DIFF
--- a/src/assets/css/DataTables/custom.css
+++ b/src/assets/css/DataTables/custom.css
@@ -122,7 +122,6 @@ input.in-row-edit {
 
 .in-row-edit-dropdown {
   background-color: #404040 !important;
-  line-height: 1 !important;
   border-radius: 0.2rem !important;
   font-size: 0.9375rem !important;
   box-shadow: 0px 2px 4px 2px rgba(0,0,0,0.5) !important;


### PR DESCRIPTION
## Bugfixes
*  Fixes a UI issue where the line hight for the drop down text boxes caused the text to not be centered