### PR TITLE
Set php default timezone to Detroit time

### DIFF
--- a/src/application/config/config.php
+++ b/src/application/config/config.php
@@ -488,7 +488,8 @@ $config['compress_output'] = FALSE;
 | helper' page of the user guide for information regarding date handling.
 |
 */
-$config['time_reference'] = 'local';
+date_default_timezone_set('America/Detroit');
+$config['time_reference'] = 'America/Detroit';
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Resolves issue #22.

## Bugfixes
*  Resolves an issue where date functions used an incorrect timezone